### PR TITLE
make Client#normalize_isbns return String of Numbers (and `,` if needed)

### DIFF
--- a/lib/openbd/client.rb
+++ b/lib/openbd/client.rb
@@ -61,13 +61,9 @@ module OpenBD
       when String
         isbns
       when Numeric
-        isbns
+        isbns.to_s
       when Array
-        params = ""
-        isbns.each do |isbn|
-          params << "#{isbn}, "
-        end
-        params.strip!.gsub(/,$/,'')
+        isbns.join(",")
       end
     end
   end

--- a/spec/openbd/client_spec.rb
+++ b/spec/openbd/client_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe OpenBD::Client do
     end
 
     it "should normalize ISBN as Integer" do
-      expect(@client.normalize_isbns(9784780801118)).to be == 9784780801118
+      expect(@client.normalize_isbns(9784780801118)).to be == "9784780801118"
     end
 
     it "should normalize ISBNs as Array of String" do
-      expect(@client.normalize_isbns(["9784780801118", "9784939015809"])).to be == "9784780801118, 9784939015809"
+      expect(@client.normalize_isbns(["9784780801118", "9784939015809"])).to be == "9784780801118,9784939015809"
     end
 
     it "should normalize ISBNs as Array of Integer" do
-      expect(@client.normalize_isbns([9784780801118, 9784939015809])).to be == "9784780801118, 9784939015809"
+      expect(@client.normalize_isbns([9784780801118, 9784939015809])).to be == "9784780801118,9784939015809"
     end
   end
 end


### PR DESCRIPTION
* do not return Integer
* do not use spaces

----
`OpenBD::Client#normalize_isbns`の挙動と実装を変更する提案です。挙動の変更内容はspecの差分の通りです。
その理由・意図としては、

* `normalize_isbns`というメソッド名でもあることだし、引数が数値でも文字列でも、返す値は文字列に統一した方が分かりやすそう
* 余計な空白を削除したい。APIの都合上、10,000個のISBNを数十回送りつけることが普通にある(Coverage API -> Get APIで全要素取得の場合)ので無意味ではなさそう
* 実装については、`String#<<`を使うよりも`Array#join`を使ったほうが早いし簡潔

というところです。
3番目については、以下のようなbenchmarkでは3倍以上の差がありました。

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  isbns = ["1234567890123"] * 10_000
  ret = nil
  x.report("join1") do
    params = ""
    isbns.each do |isbn|
      params << "#{isbn},"
    end
    ret = params.strip.gsub(/,$/,'')
  end
  x.report("join2") do
    ret = isbns.join(",")
  end
  x.compare!
end
```

```shell-session
$ ruby bench.rb 
Warming up --------------------------------------
               join1    12.000  i/100ms
               join2    37.000  i/100ms
Calculating -------------------------------------
               join1    135.111  (±16.3%) i/s -    660.000  in   5.063172s
               join2    476.790  (±19.3%) i/s -      2.294k in   5.017727s

Comparison:
               join2:      476.8 i/s
               join1:      135.1 i/s - 3.53x  slower
```
