### PR TITLE
show method of openbd in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ $ openbd coverage
 $ openbd schema
 $ openbd --help
 Usage: openbd <method> [arguments] [options]
+
+Supported <method>:
+  get       Find book data by ISBN(s)
+  bulk_get  Find book data by ISBN(s)
+  coverage  Show all ISBNs in openBD
+  schema    Show the JSON Schema of openBD
+
     -v, --version  print the version
     -h, --help     print help
 ```

--- a/lib/openbd/openbd_cli.rb
+++ b/lib/openbd/openbd_cli.rb
@@ -29,13 +29,13 @@ module OpenBD
 
     def parse_option
       @opts = ::Slop.parse do |o|
-        o.banner = <<~EOB
-          Usage: openbd <method> [arguments] [options]
+        o.banner = <<-EOB
+Usage: openbd <method> [arguments] [options]
 
-          Supported <method>:
-            get       Find book data by ISBN(s)
-            coverage  Show all ISBNs in openBD
-            schema    Show the JSON Schema of openBD
+Supported <method>:
+  get       Find book data by ISBN(s)
+  coverage  Show all ISBNs in openBD
+  schema    Show the JSON Schema of openBD
         EOB
         o.on '-v', '--version', 'print the version' do
           puts "openbd_api #{OpenBD::VERSION}"

--- a/lib/openbd/openbd_cli.rb
+++ b/lib/openbd/openbd_cli.rb
@@ -34,6 +34,7 @@ Usage: openbd <method> [arguments] [options]
 
 Supported <method>:
   get       Find book data by ISBN(s)
+  bulk_get  Find book data by ISBN(s)
   coverage  Show all ISBNs in openBD
   schema    Show the JSON Schema of openBD
         EOB

--- a/lib/openbd/openbd_cli.rb
+++ b/lib/openbd/openbd_cli.rb
@@ -29,7 +29,14 @@ module OpenBD
 
     def parse_option
       @opts = ::Slop.parse do |o|
-        o.banner = "Usage: openbd <method> [arguments] [options]"
+        o.banner = <<~EOB
+          Usage: openbd <method> [arguments] [options]
+
+          Supported <method>:
+            get       Find book data by ISBN(s)
+            coverage  Show all ISBNs in openBD
+            schema    Show the JSON Schema of openBD
+        EOB
         o.on '-v', '--version', 'print the version' do
           puts "openbd_api #{OpenBD::VERSION}"
           exit


### PR DESCRIPTION
`openbd -h`で使えるmethod(コマンド)が表示されてほしかったので修正してみました。