### PR TITLE
bulk_get should use POST method

### DIFF
--- a/lib/openbd/client.rb
+++ b/lib/openbd/client.rb
@@ -14,7 +14,7 @@ module OpenBD
     end
 
     def bulk_get(isbns)
-      get_request(
+      post_request(
         method: PATH_TO_GET,
         params: { isbn: normalize_isbns(isbns) },
         response_class: ::OpenBD::Responses::Get
@@ -49,11 +49,12 @@ module OpenBD
       response_class.new(faraday_response)
     end
 
-    def post_request(method, params)
+    def post_request(method:, params:, response_class:)
       faraday_response = connection.post do |req|
         req.url method
         req.body = "isbn=#{normalize_isbns(params[:isbn])}"
       end
+      response_class.new(faraday_response)
     end
 
     def normalize_isbns(isbns)

--- a/spec/openbd/client_spec.rb
+++ b/spec/openbd/client_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe OpenBD::Client do
     let!(:stub_connection) do
       Faraday.new do |conn|
         conn.adapter :test, Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.get("/v1/get?isbn=9784797336610") do
+          stub.post("/v1/get", "isbn=9784797336610") do
             [200, {}, sample_book_data]
           end
         end


### PR DESCRIPTION
bulk_getはgetと同じだと意味がないのでPOSTにでもするといいのでは…と思ったら0.4.0まではPOSTだったんですね。
たぶんエンバグしたのでは…？と思うので、POSTにしてみました。post_request()メソッドも一部修正しています。